### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/liftedinit/ghostcloud-frontend/security/code-scanning/1](https://github.com/liftedinit/ghostcloud-frontend/security/code-scanning/1)

**How to, in general terms, fix the problem:**  
Add a `permissions` block to the workflow or the specific job(s) in `.github/workflows/docker.yml` to restrict the `GITHUB_TOKEN` to the minimum privilege required, typically `contents: read` if only checkout/build/push actions are performed.

**Detailed best fix:**  
Since all jobs in the workflow appear to only require read access to the code (checkout), and the Docker builds/pushes are done with Docker Hub credentials, we can set the most restrictive required permission at the workflow root to apply it to all jobs.

**Where to change:**  
Insert the following between lines 2 and 3 of `.github/workflows/docker.yml`:
```yaml
permissions:
  contents: read
```
No imports or other definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
