### PR TITLE
fix: dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ FROM base AS deps
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json package-lock.json* pnpm-lock.yaml* .npmrc* bun.lockb ./
+COPY package.json package-lock.json* pnpm-lock.yaml* .npmrc* bun.lock* ./
 RUN \
   if [ -f package-lock.json ]; then npm ci; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  elif [ -f bun.lockb ]; then bun install --no-save; \
+  elif [ -f bun.lockb ] || [ -f bun.lock ]; then bun install --no-save; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -32,7 +32,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN \
   if [ -f package-lock.json ]; then npm run build; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  elif [ -f bun.lockb ]; then bun run build; \
+  elif [ -f bun.lockb ] || [ -f bun.lock ]; then bun run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve compatibility with Bun's lockfile naming conventions. Specifically, it ensures that both `bun.lockb` and the newer `bun.lock` files are supported during dependency installation and build steps.

**Dependency management updates:**

* The `COPY` command now includes both `bun.lockb` and `bun.lock` files, ensuring that either lockfile is available for Bun installations.
* The dependency installation command checks for both `bun.lockb` and `bun.lock` files, allowing Bun to install dependencies regardless of which lockfile is present.

**Build process updates:**

* The build command now supports both `bun.lockb` and `bun.lock` files, enabling the build step to work with either lockfile format.